### PR TITLE
Support non standard namespace

### DIFF
--- a/knative-build/templates/build-bot-clusterrolebinding.yaml
+++ b/knative-build/templates/build-bot-clusterrolebinding.yaml
@@ -10,5 +10,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: knative-build-bot
-  namespace: jx
+  namespace: {{ .Release.Namespace }}
 {{- end }}


### PR DESCRIPTION
Make ClusterRoleBinding knative-build-bot support non standard namespace