### PR TITLE
Add missing privileges to knative-build-bot to perform helm releases

### DIFF
--- a/knative-build/templates/build-bot-role.yaml
+++ b/knative-build/templates/build-bot-role.yaml
@@ -35,6 +35,22 @@ rules:
   - list
   - watch
 - apiGroups:
+  - jenkins.io
+  resources:
+  - users
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - jenkins.io
+  resources:
+  - releases
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - ""
   resources:
   - namespaces

--- a/knative-build/templates/build-bot-role.yaml
+++ b/knative-build/templates/build-bot-role.yaml
@@ -48,6 +48,7 @@ rules:
   - releases
   verbs:
   - get
+  - create
   - list
   - watch
 - apiGroups:

--- a/knative-build/templates/build-bot-tiller-role.yaml
+++ b/knative-build/templates/build-bot-tiller-role.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.build.auth.git.username }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: knative-build-bot-{{ .Release.Namespace }}
+  namespace: {{ .Values.tillerNamespace }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods/portforward
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+{{- end }}

--- a/knative-build/templates/build-bot-tiller-rolebinding.yaml
+++ b/knative-build/templates/build-bot-tiller-rolebinding.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.build.auth.git.username }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: knative-build-bot-{{ .Release.Namespace }}
+  namespace: {{ .Values.tillerNamespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: knative-build-bot-{{ .Release.Namespace }}
+subjects:
+- kind: ServiceAccount
+  name: knative-build-bot
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/knative-build/values.yaml
+++ b/knative-build/values.yaml
@@ -33,3 +33,4 @@ build:
       password:
       # username: my-bot
       # password: my-bot-token
+tillerNamespace: kube-system


### PR DESCRIPTION
* jenkins.io users/releases get/list/watch
* Allow helm to talk to tiller - https://github.com/helm/helm/blob/master/docs/rbac.md#helm-and-role-based-access-control

This should hopefully allow to perform a helm release without using `helm` service account which has cluster admin.