### PR TITLE
fix: allow knative-build-bot to ing/services

### DIFF
--- a/knative-build/templates/build-bot-clusterrole.yaml
+++ b/knative-build/templates/build-bot-clusterrole.yaml
@@ -20,4 +20,18 @@ rules:
   verbs:
   - create
   - get
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
 {{- end }}


### PR DESCRIPTION
To allow `knative-build-bot` to access `ingresses` and `services` at cluster level as preview environment is in different namespace from `jx`