### PR TITLE
Enable read access to extensions

### DIFF
--- a/knative-build/templates/build-bot-role.yaml
+++ b/knative-build/templates/build-bot-role.yaml
@@ -100,4 +100,11 @@ rules:
   - list
   - get
   - update
+- apiGroups:
+  - jenkins.io
+  resources:
+  - extensions
+  verbs:
+  - get
+  - list
 {{- end }}


### PR DESCRIPTION
Permit use of `jx step pre extend` on `master` builds.